### PR TITLE
compute and store parent pdg (requires SusyNtuple b1c8fd9)

### DIFF
--- a/Root/SusyNtMaker.cxx
+++ b/Root/SusyNtMaker.cxx
@@ -12,8 +12,6 @@
 #include "SusyNtuple/SusyNtTools.h"
 #include "SusyNtuple/WhTruthExtractor.h"
 
-#include <vector>
-
 using namespace std;
 
 #define GeV 1000.


### PR DESCRIPTION
A small improvement to store the pdg of the parent from the mc truth.
(needed for Daniel A.'s study on the ttbar truth).
Tested on `McAtNloJimmy_CT10_ttbar_LeptonFilter` and `Herwigpp_UEEE3_CTEQ6L1_DGnoSL_TB10_050_100_100_2L`.
