### PR TITLE
Consistent cmd-line options

### DIFF
--- a/Root/SusyNtMaker.cxx
+++ b/Root/SusyNtMaker.cxx
@@ -50,7 +50,6 @@ SusyNtMaker::SusyNtMaker() :
     m_filter(true),
     m_nLepFilter(0),
     m_nLepTauFilter(2),
-    m_filterTrigger(false),
     m_saveContTaus(false),
     m_isWhSample(false),
     m_hDecay(0),
@@ -2041,11 +2040,6 @@ bool SusyNtMaker::passObjectlevelSelection()
     if(m_filter) {
         pass = pass_nLepFilter;
     }
-  //  bool trig_has_fired( h_passTrigLevel->Integral(0,-1) > 0. ); // check if any of the triggers fired
-  //  if(m_filter) {
-  //      if(m_filterTrigger) { pass = (pass_nLepFilter && trig_has_fired); }
-  //      else { pass = pass_nLepFilter; }
-  //  }
     if(m_dbg>=5 && !pass)
         cout << "SusyNtMaker: fail passObjectlevelSelection " << endl;
     return pass;

--- a/Root/XaodAnalysis.cxx
+++ b/Root/XaodAnalysis.cxx
@@ -55,7 +55,6 @@ XaodAnalysis::XaodAnalysis() :
     m_sumOfWeightsSquared(0),
     m_isAF2(false),
     m_is8TeV(true),
-    m_d3pdTag(D3PD_p1328),
     m_selectPhotons(false),
     m_selectTaus(false),
     m_selectTruth(false),

--- a/Root/XaodAnalysis.cxx
+++ b/Root/XaodAnalysis.cxx
@@ -58,7 +58,6 @@ XaodAnalysis::XaodAnalysis() :
     m_selectPhotons(false),
     m_selectTaus(false),
     m_selectTruth(false),
-    // m_metFlavor(SUSYMet::Default),
     m_doMetMuCorr(false),
     m_doMetFix(false),
     m_lumi(LUMI_A_A4),
@@ -2091,18 +2090,6 @@ int XaodAnalysis::getHFORDecision()
     //                               m_event.mc.parent_index(),
     //                               m_event.mc.child_index(),
     //                               HforToolD3PD::ALL); //HforToolD3PD::DEFAULT
-}
-//----------------------------------------------------------
-void XaodAnalysis::setMetFlavor(string metFlav)
-{
-    // if(metFlav=="STVF") m_metFlavor = SUSYMet::STVF;
-    // else if(metFlav=="STVF_JVF") m_metFlavor = SUSYMet::STVF_JVF;
-    // else if(metFlav=="Default") m_metFlavor = SUSYMet::Default;
-    // else{
-    //   cout << "XaodAnalysis::setMetFlavor : ERROR : MET flavor " << metFlav
-    //        << " is not supported!" << endl;
-    //   abort();
-    // }
 }
 //----------------------------------------------------------
 void XaodAnalysis::dumpEvent()

--- a/SusyCommon/SusyNtMaker.h
+++ b/SusyCommon/SusyNtMaker.h
@@ -149,9 +149,6 @@ class SusyNtMaker : public XaodAnalysis
     // Set light lepton + tau filter
     void setNLepTauFilter(uint nLepTau) { m_nLepTauFilter = nLepTau; }
 
-    // Toggle trigger filtering
-    void setFilterTrigger(bool filter=true) { m_filterTrigger = filter; }
-
     // Toggle saving container taus instead of selected taus
     void setSaveContTaus(bool saveContTaus=true) { m_saveContTaus = saveContTaus; }
     static bool guessWhetherIsWhSample(const TString &samplename);
@@ -192,9 +189,6 @@ class SusyNtMaker : public XaodAnalysis
     bool                m_filter;       // Flag to turn off filtering for signal samples
     uint                m_nLepFilter;   // Number of light leptons to filter on.
     uint                m_nLepTauFilter;// Number of leptons (light+tau) to filter on.
-    bool                m_filterTrigger;// Only save events that pass any of our triggers
-    int                 m_triggerSet;   // Set which triggers are stored
-    std::vector<std::string> m_triggerNames;
     bool                m_saveContTaus; // Save container taus instead of selected taus
 
     // Some useful flags

--- a/SusyCommon/XaodAnalysis.h
+++ b/SusyCommon/XaodAnalysis.h
@@ -322,7 +322,6 @@ namespace Susy {
     void setSelectTaus(bool doIt) { m_selectTaus = doIt; } ///< Toggle tau selection and overlap removal
     void setSelectTruthObjects(bool doIt) { m_selectTruth = doIt; } ///< Set-Get truth selection
     bool getSelectTruthObjects(         ) { return m_selectTruth; }
-    void setMetFlavor(std::string metFlav); ///< only STVF and STVF_JVF are available (anything else will raise an error)
     void setDoMetMuonCorrection(bool doMetMuCorr) { m_doMetMuCorr = doMetMuCorr; }
     void setDoMetFix(bool doMetFix) { m_doMetFix = doMetFix; }
     /// whether the options specified by the user are consistent with the event info
@@ -392,7 +391,6 @@ namespace Susy {
     bool                        m_selectTaus;   // Toggle tau selection and overlap removal
     bool                        m_selectTruth;  // Toggle truth selection
 
-    /* SUSYMet::met_definition     m_metFlavor;    // MET flavor enum (e.g. STVF, STVF_JVF) */
     bool                        m_doMetMuCorr;  // Control MET muon Eloss correction in SUSYTools
     bool                        m_doMetFix;     // Control MET Egamma-jet overlap fix in SUSYTools
     //bool                      m_useMetMuons;  // Use appropriate muons for met

--- a/SusyCommon/XaodAnalysis.h
+++ b/SusyCommon/XaodAnalysis.h
@@ -317,7 +317,6 @@ namespace Susy {
     TString sample() { return m_sample; } ///< Sample name - used to set isMC flag
     XaodAnalysis& setSample(TString s) { m_sample = s; return *this; }
     void setAF2(bool isAF2=true) { m_isAF2 = isAF2; } ///< AF2 flag
-    void setD3PDTag(D3PDTag tag) { m_d3pdTag = tag; } ///< Set SUSY D3PD tag to know which branches are ok
     void setSys(bool sysOn){ m_sys = sysOn; }; ///< Set sys run
     void setSelectPhotons(bool doIt) { m_selectPhotons = doIt; } ///< Toggle photon selection
     void setSelectTaus(bool doIt) { m_selectTaus = doIt; } ///< Toggle tau selection and overlap removal
@@ -388,8 +387,6 @@ namespace Susy {
 
     bool                        m_isSusySample; // is susy grid sample
     int                         m_susyFinalState;// susy subprocess
-
-    D3PDTag                     m_d3pdTag;      // SUSY D3PD tag
 
     bool                        m_selectPhotons;// Toggle photon selection
     bool                        m_selectTaus;   // Toggle tau selection and overlap removal

--- a/util/NtMaker.cxx
+++ b/util/NtMaker.cxx
@@ -24,89 +24,89 @@ using Susy::SusyNtMaker;
 
 void help()
 {
-  cout << "  Options:"                          << endl;
-  cout << "  -n number of events to process"    << endl;
-  cout << "     defaults: -1 (all events)"      << endl;
+  cout<<"  Options:"                         <<endl;
+  cout<<"  -n number of events to process"   <<endl;
+  cout<<"     defaults: -1 (all events)"     <<endl;
 
-  cout << "  -k number of events to skip"       << endl;
-  cout << "     defaults: 0"                    << endl;
+  cout<<"  -k number of events to skip"      <<endl;
+  cout<<"     defaults: 0"                   <<endl;
 
-  cout << "  -d debug printout level"           << endl;
-  cout << "     defaults: 0 (quiet) "           << endl;
+  cout<<"  -d debug printout level"          <<endl;
+  cout<<"     defaults: 0 (quiet) "          <<endl;
 
-  cout << "  -f name of input filelist"         << endl;
-  cout << "     defaults: fileList.txt"         << endl;
+  cout<<"  -f name of input filelist"        <<endl;
+  cout<<"     defaults: fileList.txt"        <<endl;
 
-  cout << "  -s sample name, sets isMC flag"    << endl;
-  cout << "     use e.g. 'ttbar', 'DataG', etc" << endl;
+  cout<<"  -s sample name, sets isMC flag"   <<endl;
+  cout<<"     use e.g. 'ttbar', 'DataG', etc"<<endl;
 
-  cout << "  -w set sum of mc weights for norm" << endl;
-  cout << "     default: 1"                     << endl;
+  cout<<"  -w set sum of mc weights for norm"<<endl;
+  cout<<"     default: 1"                    <<endl;
 
-  cout << "  -x set cross section"              << endl;
-  cout << "     default: -1 (use susy db)"      << endl;
+  cout<<"  -x set cross section"             <<endl;
+  cout<<"     default: -1 (use susy db)"     <<endl;
 
-  cout << "  -l set lumi"                       << endl;
-  cout << "     default: 5312/pb"               << endl;
+  cout<<"  -l set lumi"                      <<endl;
+  cout<<"     default: 5312/pb"              <<endl;
 
-  cout << "  -m write output ntuple"            << endl;
-  cout << "     default: 1 (true)"              << endl;
+  cout<<"  -m write output ntuple"           <<endl;
+  cout<<"     default: 1 (true)"             <<endl;
 
-  cout << "  --grl specify GRL"                 << endl;
-  cout << "     default: set in cxx"            << endl;
+  cout<<"  --grl specify GRL"                <<endl;
+  cout<<"     default: set in cxx"           <<endl;
 
-  cout << "  --sys will turn on systematic run" << endl;
-  cout << "     default: off"                   << endl;
+  cout<<"  --sys will turn on systematic run"<<endl;
+  cout<<"     default: off"                  <<endl;
 
-  cout << "  --savePh will save photons"        << endl;
-  cout << "     default: off"                   << endl;
+  cout<<"  --savePh will save photons"       <<endl;
+  cout<<"     default: off"                  <<endl;
 
-  cout << "  --saveTau will save taus"          << endl;
-  cout << "     default: off"                   << endl;
+  cout<<"  --saveTau will save taus"         <<endl;
+  cout<<"     default: off"                  <<endl;
 
-  cout << "  --saveContTau will save container" << endl;
-  cout << "     taus instead of selected"       << endl;
+  cout<<"  --saveContTau will save container"<<endl;
+  cout<<"     taus instead of selected"      <<endl;
 
-  cout << "  --saveTruth will save truth"       << endl;
-  cout << "     default: off"                   << endl;
+  cout<<"  --saveTruth will save truth"      <<endl;
+  cout<<"     default: off"                  <<endl;
 
-  cout << "  --af2 specifies AF2 samples"       << endl;
-  cout << "     default: off"                   << endl;
+  cout<<"  --af2 specifies AF2 samples"      <<endl;
+  cout<<"     default: off"                  <<endl;
 
-  cout << "  --d3pd1032 sets d3pd tag to p1032" << endl;
-  cout << "     default: p1181"                 << endl;
+  cout<<"  --d3pd1032 sets d3pd tag to p1032"<<endl;
+  cout<<"     default: p1181"                <<endl;
 
-  cout << "  --metFlav set met flavor"          << endl;
-  cout << "     default: Default"               << endl;
+  cout<<"  --metFlav set met flavor"         <<endl;
+  cout<<"     default: Default"              <<endl;
 
-  //cout << "  --useMetMuons set to use met muons"<< endl;
-  //cout << "     for calculating missing energy "<< endl;
-  //cout << "     default: off"                   << endl;
+  //cout<<"  --useMetMuons set to use met muons"<< endl;
+  //cout<<"     for calculating missing energy "<< endl;
+  //cout<<"     default: off"                  <<endl;
 
-  //cout << "  --doMetFix turn on MET ele-jet"    << endl;
-  //cout << "     overlap fix"                    << endl;
-  //cout << "     default: off"                   << endl;
+  //cout<<"  --doMetFix turn on MET ele-jet"   <<endl;
+  //cout<<"     overlap fix"                   <<endl;
+  //cout<<"     default: off"                  <<endl;
 
-  cout << "  --filterOff turns off filtering"   << endl;
-  cout << "     default: filter is on"          << endl;
+  cout<<"  --filterOff turns off filtering"  <<endl;
+  cout<<"     default: filter is on"         <<endl;
 
-  cout << "  --nLepFilter number of light leps" << endl;
-  cout << "     to filter on. Default: 0"       << endl;
+  cout<<"  --nLepFilter number of light leps"<<endl;
+  cout<<"     to filter on. Default: 0"      <<endl;
 
-  cout << "  --nLepTauFilter number of total"   << endl;
-  cout << "     light+tau to filter on."        << endl;
-  cout << "     Default: 2"                     << endl;
+  cout<<"  --nLepTauFilter number of total"  <<endl;
+  cout<<"     light+tau to filter on."       <<endl;
+  cout<<"     Default: 2"                    <<endl;
 
-  cout << "  --filterTrig turns on trigger"     << endl;
-  cout << "     filtering."                     << endl;
+  cout<<"  --filterTrig turns on trigger"    <<endl;
+  cout<<"     filtering."                    <<endl;
 
-  cout << "  --trig set which triggers are  "   << endl;
-  cout << "    stored.                      "   << endl;
-  cout << "    Default: 1 (0: Run1, 1:Run2) "   << endl;
-  cout << "--input  name of the input container" <<endl;
-  cout << "--output name of the output container"<<endl;
-  cout << "--tag    SustNtuple production tag"   <<endl;
-  cout << "  -h print this help"                << endl;
+  cout<<"  --trig set which triggers are  "  <<endl;
+  cout<<"    stored.                      "  <<endl;
+  cout<<"    Default: 1 (0: Run1, 1:Run2) "  <<endl;
+  cout<<"--input  name of the input container" <<endl;
+  cout<<"--output name of the output container"<<endl;
+  cout<<"--tag    SustNtuple production tag"   <<endl;
+  cout<<"  -h print this help"               <<endl;
 }
 
 
@@ -135,8 +135,8 @@ int main(int argc, char** argv)
   string trigset     = "run2";
   string inputContainer, outputContainer, ntTag;
 
-  cout << "SusyNtMaker" << endl;
-  cout << endl;
+  cout<<"SusyNtMaker"<<endl;
+  cout<<endl;
 
   int optind(1);
   while(optind < argc) {
@@ -173,31 +173,31 @@ int main(int argc, char** argv)
       optind++;
   } // while(optind)
 
-  cout << "flags:" << endl;
-  cout << "  sample        " << sample   << endl;
-  cout << "  nEvt          " << nEvt     << endl;
-  cout << "  nSkip         " << nSkip    << endl;
-  cout << "  dbg           " << dbg      << endl;
-  cout << "  fileList      " << fileList << endl;
-  cout << "  grl           " << grl      << endl;
-  cout << "  sys           " << sysOn    << endl;
-  cout << "  savePh        " << savePh   << endl;
-  cout << "  saveTau       " << saveTau  << endl;
-  cout << "  saveContTau   " << saveContTau << endl;
-  cout << "  saveTru       " << saveTruth<< endl;
-  cout << "  isAF2         " << isAF2    << endl;
-  cout << "  d3pdtag       " << tag      << endl;
-  cout << "  metFlav       " << metFlav  << endl;
-  cout << "  lumi          " << lumi     << endl;
-  cout << "  filter        " << filter   << endl;
-  cout << "  nLepFilter    " << nLepFilter    << endl;
-  cout << "  nLepTauFilter " << nLepTauFilter << endl;
-  cout << "  filterTrig    " << filterTrig    << endl;
-  cout << "  triggerSet    " << trigset       << endl;
-  cout << "  input         " << inputContainer  << endl;
-  cout << "  output        " << outputContainer << endl;
-  cout << "  ntTag         " << ntTag           << endl;
-  cout << endl;
+  cout<<"flags:"<<endl;
+  cout<<"  sample        "<<sample  <<endl;
+  cout<<"  nEvt          "<<nEvt    <<endl;
+  cout<<"  nSkip         "<<nSkip   <<endl;
+  cout<<"  dbg           "<<dbg     <<endl;
+  cout<<"  fileList      "<<fileList<<endl;
+  cout<<"  grl           "<<grl     <<endl;
+  cout<<"  sys           "<<sysOn   <<endl;
+  cout<<"  savePh        "<<savePh  <<endl;
+  cout<<"  saveTau       "<<saveTau <<endl;
+  cout<<"  saveContTau   "<<saveContTau<<endl;
+  cout<<"  saveTru       "<<saveTruth<< endl;
+  cout<<"  isAF2         "<<isAF2   <<endl;
+  cout<<"  d3pdtag       "<<tag     <<endl;
+  cout<<"  metFlav       "<<metFlav <<endl;
+  cout<<"  lumi          "<<lumi    <<endl;
+  cout<<"  filter        "<<filter  <<endl;
+  cout<<"  nLepFilter    "<<nLepFilter   <<endl;
+  cout<<"  nLepTauFilter "<<nLepTauFilter<<endl;
+  cout<<"  filterTrig    "<<filterTrig   <<endl;
+  cout<<"  triggerSet    "<<trigset      <<endl;
+  cout<<"  input         "<<inputContainer <<endl;
+  cout<<"  output        "<<outputContainer<<endl;
+  cout<<"  ntTag         "<<ntTag          <<endl;
+  cout<<endl;
 
 
   // Build the input chain
@@ -236,13 +236,13 @@ int main(int argc, char** argv)
 
   // Run the job
   if(nEvt<0) nEvt = nEntries;
-  cout << endl;
-  cout << "Total entries:   " << nEntries << endl;
-  cout << "Process entries: " << nEvt << endl;
+  cout<<endl;
+  cout<<"Total entries:   "<<nEntries<<endl;
+  cout<<"Process entries: "<<nEvt<<endl;
   chain->Process(susyAna, sample.c_str(), nEvt, nSkip);
 
-  cout << endl;
-  cout << "SusyNtMaker job done" << endl;
+  cout<<endl;
+  cout<<"SusyNtMaker job done"<<endl;
 
   delete chain;
   return 0;

--- a/util/NtMaker.cxx
+++ b/util/NtMaker.cxx
@@ -24,89 +24,29 @@ using Susy::SusyNtMaker;
 
 void help()
 {
-  cout<<"  Options:"                         <<endl;
-  cout<<"  -n number of events to process"   <<endl;
-  cout<<"     defaults: -1 (all events)"     <<endl;
-
-  cout<<"  -k number of events to skip"      <<endl;
-  cout<<"     defaults: 0"                   <<endl;
-
-  cout<<"  -d debug printout level"          <<endl;
-  cout<<"     defaults: 0 (quiet) "          <<endl;
-
-  cout<<"  -f name of input filelist"        <<endl;
-  cout<<"     defaults: fileList.txt"        <<endl;
-
-  cout<<"  -s sample name, sets isMC flag"   <<endl;
-  cout<<"     use e.g. 'ttbar', 'DataG', etc"<<endl;
-
-  cout<<"  -w set sum of mc weights for norm"<<endl;
-  cout<<"     default: 1"                    <<endl;
-
-  cout<<"  -x set cross section"             <<endl;
-  cout<<"     default: -1 (use susy db)"     <<endl;
-
-  cout<<"  -l set lumi"                      <<endl;
-  cout<<"     default: 5312/pb"              <<endl;
-
-  cout<<"  -m write output ntuple"           <<endl;
-  cout<<"     default: 1 (true)"             <<endl;
-
-  cout<<"  --grl specify GRL"                <<endl;
-  cout<<"     default: set in cxx"           <<endl;
-
-  cout<<"  --sys will turn on systematic run"<<endl;
-  cout<<"     default: off"                  <<endl;
-
-  cout<<"  --savePh will save photons"       <<endl;
-  cout<<"     default: off"                  <<endl;
-
-  cout<<"  --saveTau will save taus"         <<endl;
-  cout<<"     default: off"                  <<endl;
-
-  cout<<"  --saveContTau will save container"<<endl;
-  cout<<"     taus instead of selected"      <<endl;
-
-  cout<<"  --saveTruth will save truth"      <<endl;
-  cout<<"     default: off"                  <<endl;
-
-  cout<<"  --af2 specifies AF2 samples"      <<endl;
-  cout<<"     default: off"                  <<endl;
-
-  cout<<"  --d3pd1032 sets d3pd tag to p1032"<<endl;
-  cout<<"     default: p1181"                <<endl;
-
-  cout<<"  --metFlav set met flavor"         <<endl;
-  cout<<"     default: Default"              <<endl;
-
-  //cout<<"  --useMetMuons set to use met muons"<< endl;
-  //cout<<"     for calculating missing energy "<< endl;
-  //cout<<"     default: off"                  <<endl;
-
-  //cout<<"  --doMetFix turn on MET ele-jet"   <<endl;
-  //cout<<"     overlap fix"                   <<endl;
-  //cout<<"     default: off"                  <<endl;
-
-  cout<<"  --filterOff turns off filtering"  <<endl;
-  cout<<"     default: filter is on"         <<endl;
-
-  cout<<"  --nLepFilter number of light leps"<<endl;
-  cout<<"     to filter on. Default: 0"      <<endl;
-
-  cout<<"  --nLepTauFilter number of total"  <<endl;
-  cout<<"     light+tau to filter on."       <<endl;
-  cout<<"     Default: 2"                    <<endl;
-
-  cout<<"  --filterTrig turns on trigger"    <<endl;
-  cout<<"     filtering."                    <<endl;
-
-  cout<<"  --trig set which triggers are  "  <<endl;
-  cout<<"    stored.                      "  <<endl;
-  cout<<"    Default: 1 (0: Run1, 1:Run2) "  <<endl;
-  cout<<"--input  name of the input container" <<endl;
-  cout<<"--output name of the output container"<<endl;
-  cout<<"--tag    SustNtuple production tag"   <<endl;
-  cout<<"  -h print this help"               <<endl;
+  cout<<"Options:"                                                    <<endl
+      <<"  -i|--input       name of the input container"              <<endl
+      <<"  -o|--output      name of the output container"             <<endl
+      <<"  -t|--tag         SustNtuple production tag"                <<endl
+      <<"  -n|--num-events  default: -1 (all events)"                 <<endl
+      <<"  -k|--num-skip    default: 0"                               <<endl
+      <<"  -d|--dbg-level   default: 0 (quiet) "                      <<endl
+      <<"  -f|--filelist    default: fileList.txt"                    <<endl
+      <<"  -s|--sample      default: ''"                              <<endl
+      <<"  -h|--help        print this help"                          <<endl
+      <<"  -l|--lumi        default: 5312/pb"                         <<endl /// \todo obsolete option?
+      <<"  -m|--write-nt    default: 1 (true, write tuple)"           <<endl
+      <<"  --grl            default: XaodAnalysis::defaultGrlFile()"  <<endl
+      <<"  --sys            default: off"                             <<endl
+      <<"  --savePh         save photons"                             <<endl
+      <<"  --saveTau        save taus"                                <<endl
+      <<"  --saveContTau    save container taus (instead of selected)"<<endl
+      <<"  --saveTruth      save truth info"                          <<endl
+      <<"  --af2            toggle atlas-fast-2 sample"               <<endl
+      <<"  --filterOff      save all events"                          <<endl
+      <<"  --nLepFilter     default 0 (require N  light leptons)"     <<endl
+      <<"  --nLepTauFilter  default 2 (require N lepton+tau)"         <<endl
+      <<endl;
 }
 
 
@@ -126,13 +66,9 @@ int main(int argc, char** argv)
   bool saveTruth  = false;
   bool isAF2      = false;
   bool writeNt    = true;
-  D3PDTag tag     = D3PD_p1328;
-  string metFlav  = "Default";
   bool filter     = true;
   uint nLepFilter = 0;
   uint nLepTauFilter = 2;
-  bool filterTrig = false;
-  string trigset     = "run2";
   string inputContainer, outputContainer, ntTag;
 
   cout<<"SusyNtMaker"<<endl;
@@ -141,11 +77,15 @@ int main(int argc, char** argv)
   int optind(1);
   while(optind < argc) {
       std::string sw = argv[optind];
-      if      (sw=="-n" || sw=="--num-events") { nEvt = atoi(argv[++optind]); }
+      if      (sw=="-i" || sw=="--input"     ) { inputContainer = argv[++optind]; }
+      else if (sw=="-o" || sw=="--output"    ) { outputContainer = argv[++optind]; }
+      else if (sw=="-t" || sw=="--tag"       ) { ntTag = argv[++optind]; }
+      else if (sw=="-n" || sw=="--num-events") { nEvt = atoi(argv[++optind]); }
       else if (sw=="-k" || sw=="--num-skip"  ) { nSkip = atoi(argv[++optind]); }
       else if (sw=="-d" || sw=="--dbg-level" ) { dbg = atoi(argv[++optind]); }
       else if (sw=="-f" || sw=="--filelist"  ) { fileList = argv[++optind]; }
       else if (sw=="-s" || sw=="--sample"    ) { sample = argv[++optind]; }
+      else if (sw=="-h" || sw=="--help"      ) { help(); return 0; }
       else if (sw=="-l" || sw=="--lumi"      ) { lumi = atof(argv[++optind]); }
       else if (sw=="-m" || sw=="--write-nt"  ) { writeNt = atoi(argv[++optind]); }
       else if (sw=="--grl"          ) { grl = argv[++optind]; }
@@ -155,16 +95,9 @@ int main(int argc, char** argv)
       else if (sw=="--saveContTau"  ) { saveTau = saveContTau = true; }
       else if (sw=="--saveTruth"    ) { saveTruth = true; }
       else if (sw=="--af2"          ) { isAF2 = true; }
-      else if (sw=="--d3pd1032"     ) { tag = D3PD_p1032; }
-      else if (sw=="--metFlav"      ) { metFlav = argv[++optind]; }
       else if (sw=="--filterOff"    ) { filter = false; }
       else if (sw=="--nLepFilter"   ) { nLepFilter = atoi(argv[++optind]); }
       else if (sw=="--nLepTauFilter") { nLepTauFilter = atoi(argv[++optind]); }
-      else if (sw=="--filterTrig"   ) { filterTrig = true; }
-      else if (sw=="--triggerSet"   ) { trigset = argv[++optind]; }
-      else if (sw=="--input"        ) { inputContainer = argv[++optind]; }
-      else if (sw=="--output"       ) { outputContainer = argv[++optind]; }
-      else if (sw=="--tag"          ) { ntTag = argv[++optind]; }
       else {
           cout<<"Unknown switch '"<<sw<<"'"<<endl;
           help();
@@ -186,14 +119,10 @@ int main(int argc, char** argv)
   cout<<"  saveContTau   "<<saveContTau<<endl;
   cout<<"  saveTru       "<<saveTruth<< endl;
   cout<<"  isAF2         "<<isAF2   <<endl;
-  cout<<"  d3pdtag       "<<tag     <<endl;
-  cout<<"  metFlav       "<<metFlav <<endl;
   cout<<"  lumi          "<<lumi    <<endl;
   cout<<"  filter        "<<filter  <<endl;
   cout<<"  nLepFilter    "<<nLepFilter   <<endl;
   cout<<"  nLepTauFilter "<<nLepTauFilter<<endl;
-  cout<<"  filterTrig    "<<filterTrig   <<endl;
-  cout<<"  triggerSet    "<<trigset      <<endl;
   cout<<"  input         "<<inputContainer <<endl;
   cout<<"  output        "<<outputContainer<<endl;
   cout<<"  ntTag         "<<ntTag          <<endl;
@@ -211,7 +140,6 @@ int main(int argc, char** argv)
   SusyNtMaker* susyAna = new SusyNtMaker();
   susyAna->setChain(chain);
   susyAna->setDebug(dbg);
-  susyAna->setTriggerSet(trigset);
   susyAna->setSample(sample);
   susyAna->setLumi(lumi);
   susyAna->setSys(sysOn);
@@ -220,13 +148,10 @@ int main(int argc, char** argv)
   susyAna->setSaveContTaus(saveContTau);
   susyAna->setAF2(isAF2);
   susyAna->setFillNt(writeNt);
-  susyAna->setD3PDTag(tag);
-  susyAna->setMetFlavor(metFlav);
   susyAna->setSelectTruthObjects(saveTruth);
   susyAna->setFilter(filter);
   susyAna->setNLepFilter(nLepFilter);
   susyAna->setNLepTauFilter(nLepTauFilter);
-  susyAna->setFilterTrigger(filterTrig);
   susyAna->m_inputContainerName = inputContainer;
   susyAna->m_outputContainerName = outputContainer;
   susyAna->m_productionTag = ntTag;

--- a/util/NtMaker.cxx
+++ b/util/NtMaker.cxx
@@ -128,7 +128,6 @@ int main(int argc, char** argv)
   bool writeNt    = true;
   D3PDTag tag     = D3PD_p1328;
   string metFlav  = "Default";
-  //bool doMetFix   = false;
   bool filter     = true;
   uint nLepFilter = 0;
   uint nLepTauFilter = 2;
@@ -139,63 +138,40 @@ int main(int argc, char** argv)
   cout << "SusyNtMaker" << endl;
   cout << endl;
 
-  // Read inputs to program
-  for(int i = 1; i < argc; i++) {
-    if (strcmp(argv[i], "-n") == 0)
-      nEvt = atoi(argv[++i]);
-    else if (strcmp(argv[i], "-k") == 0)
-      nSkip = atoi(argv[++i]);
-    else if (strcmp(argv[i], "-d") == 0)
-      dbg = atoi(argv[++i]);
-    else if (strcmp(argv[i], "-f") == 0)
-      fileList = argv[++i];
-    else if (strcmp(argv[i], "-s") == 0)
-      sample = argv[++i];
-    else if (strcmp(argv[i], "-l") == 0)
-      lumi = atof(argv[++i]);
-    else if (strcmp(argv[i], "-m") == 0)
-      writeNt = atoi(argv[++i]);
-    else if (strcmp(argv[i], "--grl") == 0)
-      grl = argv[++i];
-    else if (strcmp(argv[i], "--sys") == 0)
-      sysOn = true;
-    else if (strcmp(argv[i], "--savePh") == 0)
-    savePh = true;
-    else if (strcmp(argv[i], "--saveTau") == 0)
-      saveTau = true;
-    else if (strcmp(argv[i], "--saveContTau") == 0){
-      saveTau = true;
-      saveContTau = true;
-    }
-    else if (strcmp(argv[i], "--saveTruth") == 0)
-      saveTruth = true;
-    else if (strcmp(argv[i], "--af2") == 0)
-      isAF2 = true;
-    else if (strcmp(argv[i], "--d3pd1032") == 0)
-      tag = D3PD_p1032;
-    else if (strcmp(argv[i], "--metFlav") == 0)
-      metFlav = argv[++i];
-    //else if (strcmp(argv[i], "--doMetFix") == 0)
-      //doMetFix = true;
-    else if (strcmp(argv[i], "--filterOff") == 0)
-      filter = false;
-    else if (strcmp(argv[i], "--nLepFilter") == 0)
-      nLepFilter = atoi(argv[++i]);
-    else if (strcmp(argv[i], "--nLepTauFilter") == 0)
-      nLepTauFilter = atoi(argv[++i]);
-    else if (strcmp(argv[i], "--filterTrig") == 0)
-      filterTrig = true;
-    else if (strcmp(argv[i], "--triggerSet") == 0)
-      trigset = argv[++i];
-    else if (strcmp(argv[i], "--input") == 0) inputContainer = argv[++i];
-    else if (strcmp(argv[i], "--output") == 0) outputContainer = argv[++i];
-    else if (strcmp(argv[i], "--tag") == 0) ntTag = argv[++i];
-    else
-    {
-      help();
-      return 0;
-    }
-  }
+  int optind(1);
+  while(optind < argc) {
+      std::string sw = argv[optind];
+      if      (sw=="-n" || sw=="--num-events") { nEvt = atoi(argv[++optind]); }
+      else if (sw=="-k" || sw=="--num-skip"  ) { nSkip = atoi(argv[++optind]); }
+      else if (sw=="-d" || sw=="--dbg-level" ) { dbg = atoi(argv[++optind]); }
+      else if (sw=="-f" || sw=="--filelist"  ) { fileList = argv[++optind]; }
+      else if (sw=="-s" || sw=="--sample"    ) { sample = argv[++optind]; }
+      else if (sw=="-l" || sw=="--lumi"      ) { lumi = atof(argv[++optind]); }
+      else if (sw=="-m" || sw=="--write-nt"  ) { writeNt = atoi(argv[++optind]); }
+      else if (sw=="--grl"          ) { grl = argv[++optind]; }
+      else if (sw=="--sys"          ) { sysOn = true; }
+      else if (sw=="--savePh"       ) { savePh = true; }
+      else if (sw=="--saveTau"      ) { saveTau = true; }
+      else if (sw=="--saveContTau"  ) { saveTau = saveContTau = true; }
+      else if (sw=="--saveTruth"    ) { saveTruth = true; }
+      else if (sw=="--af2"          ) { isAF2 = true; }
+      else if (sw=="--d3pd1032"     ) { tag = D3PD_p1032; }
+      else if (sw=="--metFlav"      ) { metFlav = argv[++optind]; }
+      else if (sw=="--filterOff"    ) { filter = false; }
+      else if (sw=="--nLepFilter"   ) { nLepFilter = atoi(argv[++optind]); }
+      else if (sw=="--nLepTauFilter") { nLepTauFilter = atoi(argv[++optind]); }
+      else if (sw=="--filterTrig"   ) { filterTrig = true; }
+      else if (sw=="--triggerSet"   ) { trigset = argv[++optind]; }
+      else if (sw=="--input"        ) { inputContainer = argv[++optind]; }
+      else if (sw=="--output"       ) { outputContainer = argv[++optind]; }
+      else if (sw=="--tag"          ) { ntTag = argv[++optind]; }
+      else {
+          cout<<"Unknown switch '"<<sw<<"'"<<endl;
+          help();
+          return 0;
+      }
+      optind++;
+  } // while(optind)
 
   cout << "flags:" << endl;
   cout << "  sample        " << sample   << endl;
@@ -212,7 +188,6 @@ int main(int argc, char** argv)
   cout << "  isAF2         " << isAF2    << endl;
   cout << "  d3pdtag       " << tag      << endl;
   cout << "  metFlav       " << metFlav  << endl;
-  //cout << "  doMetFix      " << doMetFix << endl;
   cout << "  lumi          " << lumi     << endl;
   cout << "  filter        " << filter   << endl;
   cout << "  nLepFilter    " << nLepFilter    << endl;
@@ -248,7 +223,6 @@ int main(int argc, char** argv)
   susyAna->setD3PDTag(tag);
   susyAna->setMetFlavor(metFlav);
   susyAna->setSelectTruthObjects(saveTruth);
-  //susyAna->setDoMetFix(doMetFix);
   susyAna->setFilter(filter);
   susyAna->setNLepFilter(nLepFilter);
   susyAna->setNLepTauFilter(nLepTauFilter);


### PR DESCRIPTION
cleanup the cmd-line code:
- make sure we're consistently using '-' for short opt and '--' for long opt
- shorten parsing by using string comparison
There's probably some similar work to be done in SusyNtuple too.