### PR TITLE
Debug XaodAnalysis::truthElectronCharge()

### DIFF
--- a/Root/SusyNtMaker.cxx
+++ b/Root/SusyNtMaker.cxx
@@ -520,6 +520,7 @@ void SusyNtMaker::storeElectron(const xAOD::Electron &in)
         //AT: 05-02-15: Issue accessing Aux of trackParticle in truthElectronCharge. Info not in derived AOD ?
         //if(eleIsOfType(in, eleID::LooseLH))
         // crash p1874 out.isChargeFlip  = m_isMC ? isChargeFlip(in.charge(),truthElectronCharge(in)) : false;
+        out.truthCharge =  truthEle ? truthEle->charge() : 0;
     }
 
     //////////////////////////////////////


### PR DESCRIPTION
This is  the error reported at 27a0d275112cbeddaf3dcf01dc1f2f70a4ff8927
An example log from a failing job can be found at this link
http://aipanda054.cern.ch/media/filebrowser/b9a06455-f65b-44ab-acb3-78297f72423a/tarball_PandaJob_2474578499_ANALY_BNL_SHORT/athena_stdout.txt
The files to reproduce the crash are at
`gpatlas2:/scratch/gerbaudo/xaod_example_input/mc14_8TeV.126937.PowhegPythia8_AU2CT10_ZZ_4e_mll4_2pt5.merge.DAOD_SUSY1.e1280_s1933_s1911_r5591_r5625_p1874/*.root*`